### PR TITLE
Issue #21: Added benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 test/browser/chai
 test/browser/mocha
 test/browser/extend-with-super.js
+benchmark/results

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -157,7 +157,8 @@ module.exports = function(grunt) {
 
   grunt.registerTask('test', [
     'mocha',
-    'mochaTest'
+    'mochaTest',
+    'benchmark'
   ]);
 
   grunt.registerTask('build', [

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,8 +1,11 @@
 'use strict';
 
+var version = require('./package.json').version;
+
 module.exports = function(grunt) {
 
   var jsFiles = [
+    'benchmark/**/*.js',
     'lib/**/*.js',
     'test/**/*.js',
     'Gruntfile.js',
@@ -124,6 +127,16 @@ module.exports = function(grunt) {
       all: [
         'test/node/**/*-test.js'
       ]
+    },
+
+    benchmark: {
+      options: {
+        displayResults: true
+      },
+      singleTest: {
+        src: ['benchmark/extend-with-super.js'],
+        dest: 'benchmark/results/extend-with-super.' + version + '.csv'
+      }
     }
 
   });

--- a/benchmark/extend-with-super.js
+++ b/benchmark/extend-with-super.js
@@ -1,0 +1,78 @@
+var extendWithSuper = require('../lib/extend-with-super');
+
+function extendObjectLiterals() {
+  var testObj = {
+    notFuncProp: 'testing',
+    funcProp: function() {
+      return 'hello';
+    },
+    funcPropWithArgs: function(arg1, arg2) {
+      return arg1 + ' ' + arg2;
+    }
+  };
+
+  var test2Obj = {
+    notFuncProp: 'should not be testing',
+    funcProp: function() {
+      var hello = this._super();
+      return hello + ' world';
+    },
+    funcPropWithArgs: function(arg1, arg2) {
+      var original = this._super('Hello', 'world!');
+      return original + ' ' + arg1 + ' ' + arg2;
+    }
+  };
+  var extendedObj = {};
+  return extendWithSuper(extendedObj, testObj, test2Obj);
+}
+
+function extendArrays() {
+
+  var testArr = [function() {
+    return 'hello';
+  }];
+
+  var test2Arr = [function() {
+    var hello = this._super();
+    return hello + ' world';
+  }];
+
+  var extendedArr = [function() {}];
+
+  return extendWithSuper(extendedArr, testArr, test2Arr);
+}
+
+function extendingInScope() {
+
+  function Super() {}
+
+  extendWithSuper.apply(Super, [Super.prototype, {
+    notFuncProp: 'testing',
+    funcProp: function() {
+      return 'hello';
+    }
+  }, {
+    notFuncProp: 'should not be testing',
+    funcProp: function() {
+      var notFuncProp = this.prototype.notFuncProp;
+      var hello = this._super();
+      return hello + ' world ' + notFuncProp;
+    }
+  }]);
+
+  return new Super();
+}
+
+module.exports = {
+  name: 'Extend with super benchmark progress.',
+  tests: [{
+    name: 'Extending object literals.',
+    fn: extendObjectLiterals
+  }, {
+    name: 'Extending arrays.',
+    fn: extendArrays
+  }, {
+    name: 'Extending object literals in scope.',
+    fn: extendingInScope
+  }]
+};

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "precommit": "./node_modules/.bin/grunt pre-commit",
     "test": "npm run bower; ./node_modules/.bin/grunt test",
     "coverage": "./node_modules/.bin/grunt mochacov",
-    "build": "./node_modules/.bin/grunt build"
+    "build": "./node_modules/.bin/grunt build",
+    "benchmark": "./node_modules/.bin/grunt benchmark"
   },
   "main": "lib/extend-with-super.js",
   "repository": {
@@ -27,6 +28,7 @@
     "bower": "1.3.12",
     "chai": "1.10.0",
     "grunt": "0.4.5",
+    "grunt-benchmark": "0.3.0",
     "grunt-browserify": "3.2.1",
     "grunt-cli": "0.1.13",
     "grunt-contrib-clean": "0.6.0",
@@ -66,6 +68,7 @@
         "lib"
       ],
       "data-cover-never": [
+        "benchmark",
         "dist",
         "Gruntfile.js",
         "node_modules",


### PR DESCRIPTION
Added grunt-benchmark task to measure perf between tags.
Task can be ran with: npm run benchmark.
- Add: benchmark grunt task
- Add: Updated jsfiles in gruntfile
- Add: Package.json coverage config to ignore benchmark
- Add: .gitignore to ignore benchmark results (results can be seen in stdout)
